### PR TITLE
#27(chat 디렉토리) : 채팅 전송, 채팅 읽기, 채팅방 미리보기(최근 채팅 축약 정보), 채팅방 메세지 가져오기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
 //    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/api/chat/controller/ChatController.java
+++ b/src/main/java/com/example/api/chat/controller/ChatController.java
@@ -1,11 +1,18 @@
 package com.example.api.chat.controller;
 
 import com.example.api.chat.controller.dto.request.ChatSendRequest;
+import com.example.api.chat.controller.dto.request.ReadRequest;
+import com.example.api.chat.controller.dto.request.UserIdRequest;
+import com.example.api.chat.controller.dto.response.ChatSummaryResponse;
 import com.example.api.chat.service.ChatService;
+import com.example.api.domain.Chat;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,5 +22,21 @@ public class ChatController {
     @MessageMapping("/send")
     public void sendMessage(@Payload ChatSendRequest chatRequest) {
         chatService.sendChat(chatRequest);
+    }
+
+    @MessageMapping("/read")
+    public void readMessage(@Payload ReadRequest readRequest) {
+        chatService.readChats(readRequest);
+    }
+
+    @GetMapping("/chat/summaries")
+    public ResponseEntity<ChatSummaryResponse> getChatSummaries(@RequestBody UserIdRequest userIdRequest) {
+        return ResponseEntity.ok(chatService.getChatSummaries(userIdRequest));
+    }
+
+    @GetMapping("/chat/room/{roomId}/chats")
+    public ResponseEntity<List<Chat>> getMessages(@PathVariable("roomId") Long chatRoomId,
+                                                   @RequestParam(value = "lastChatId", required = false) String chatId) {
+        return ResponseEntity.ok(chatService.getChats(chatRoomId,chatId));
     }
 }

--- a/src/main/java/com/example/api/chat/controller/ChatController.java
+++ b/src/main/java/com/example/api/chat/controller/ChatController.java
@@ -1,0 +1,20 @@
+package com.example.api.chat.controller;
+
+import com.example.api.chat.controller.dto.request.ChatSendRequest;
+import com.example.api.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+    private final ChatService chatService;
+
+    @MessageMapping("/send")
+    public void sendMessage(@Payload ChatSendRequest messageRequest) {
+        String result = chatService.sendMessage(messageRequest);
+        System.out.println("result = " + result);
+    }
+}

--- a/src/main/java/com/example/api/chat/controller/ChatController.java
+++ b/src/main/java/com/example/api/chat/controller/ChatController.java
@@ -13,8 +13,7 @@ public class ChatController {
     private final ChatService chatService;
 
     @MessageMapping("/send")
-    public void sendMessage(@Payload ChatSendRequest messageRequest) {
-        String result = chatService.sendMessage(messageRequest);
-        System.out.println("result = " + result);
+    public void sendMessage(@Payload ChatSendRequest chatRequest) {
+        chatService.sendChat(chatRequest);
     }
 }

--- a/src/main/java/com/example/api/chat/controller/dto/RequestUserId.java
+++ b/src/main/java/com/example/api/chat/controller/dto/RequestUserId.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto;
+
+public record requestUserId() {
+}

--- a/src/main/java/com/example/api/chat/controller/dto/RequestUserId.java
+++ b/src/main/java/com/example/api/chat/controller/dto/RequestUserId.java
@@ -1,4 +1,0 @@
-package com.example.api.chat.controller.dto;
-
-public record RequestUserId(Long userId) {
-}

--- a/src/main/java/com/example/api/chat/controller/dto/RequestUserId.java
+++ b/src/main/java/com/example/api/chat/controller/dto/RequestUserId.java
@@ -1,4 +1,4 @@
 package com.example.api.chat.controller.dto;
 
-public record requestUserId() {
+public record RequestUserId(Long userId) {
 }

--- a/src/main/java/com/example/api/chat/controller/dto/request/ChatSendRequest.java
+++ b/src/main/java/com/example/api/chat/controller/dto/request/ChatSendRequest.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto.request;
+
+public record ChatSendRequest(Long roomId, Long senderId, Long receiverId, String content) {
+}

--- a/src/main/java/com/example/api/chat/controller/dto/request/ReadRequest.java
+++ b/src/main/java/com/example/api/chat/controller/dto/request/ReadRequest.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto.request;
+
+public record ReadRequest(Long roomId, Long userId) {
+}

--- a/src/main/java/com/example/api/chat/controller/dto/request/UserIdRequest.java
+++ b/src/main/java/com/example/api/chat/controller/dto/request/UserIdRequest.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto.request;
+
+public record UserIdRequest(Long userId) {
+}

--- a/src/main/java/com/example/api/chat/controller/dto/response/ChatSummaryResponse.java
+++ b/src/main/java/com/example/api/chat/controller/dto/response/ChatSummaryResponse.java
@@ -1,4 +1,9 @@
 package com.example.api.chat.controller.dto.response;
 
-public class ChatSummaryResponse {
+import com.example.api.chat.domain.ChatSummary;
+import com.example.api.domain.ChatRoom;
+
+import java.util.List;
+
+public record ChatSummaryResponse(List<ChatRoom> chatRooms, List<ChatSummary> chatSummaries) {
 }

--- a/src/main/java/com/example/api/chat/controller/dto/response/ChatSummaryResponse.java
+++ b/src/main/java/com/example/api/chat/controller/dto/response/ChatSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto.response;
+
+public class ChatSummaryResponse {
+}

--- a/src/main/java/com/example/api/chat/controller/dto/response/ReadResponse.java
+++ b/src/main/java/com/example/api/chat/controller/dto/response/ReadResponse.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto.response;
+
+public record ReadResponse(Long readBy) {
+}

--- a/src/main/java/com/example/api/chat/domain/ChatSummary.java
+++ b/src/main/java/com/example/api/chat/domain/ChatSummary.java
@@ -1,4 +1,6 @@
-package com.example.api.chat.controller.dto.response;
+package com.example.api.chat.domain;
 
-public record ChatSummary() {
+import java.util.Date;
+
+public record ChatSummary(Long roomId, String lastMessageContent, Date lastMessageTime, Long numberOfUnreadMessages) {
 }

--- a/src/main/java/com/example/api/chat/domain/ChatSummary.java
+++ b/src/main/java/com/example/api/chat/domain/ChatSummary.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.controller.dto.response;
+
+public record ChatSummary() {
+}

--- a/src/main/java/com/example/api/chat/repository/ChatRepository.java
+++ b/src/main/java/com/example/api/chat/repository/ChatRepository.java
@@ -1,0 +1,9 @@
+package com.example.api.chat.repository;
+
+import com.example.api.domain.Chat;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRepository extends MongoRepository<Chat, String> {
+}

--- a/src/main/java/com/example/api/chat/repository/ChatRepository.java
+++ b/src/main/java/com/example/api/chat/repository/ChatRepository.java
@@ -1,9 +1,12 @@
 package com.example.api.chat.repository;
 
+import com.example.api.chat.domain.ChatSummary;
 import com.example.api.domain.Chat;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface ChatRepository extends MongoRepository<Chat, String> {
+public interface ChatRepository extends MongoRepository<Chat, String>, CustomChatRepository {
 }

--- a/src/main/java/com/example/api/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/api/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.example.api.chat.repository;
+
+import com.example.api.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/example/api/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/api/chat/repository/ChatRoomRepository.java
@@ -2,8 +2,15 @@ package com.example.api.chat.repository;
 
 import com.example.api.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    @Query("select c from ChatRoom c join c.offerEmployment oe " +
+            "where oe.employee.accountId = :userId or oe.business.employer.accountId = :userId")
+    List<ChatRoom> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/api/chat/repository/CustomChatRepository.java
+++ b/src/main/java/com/example/api/chat/repository/CustomChatRepository.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.repository;
+
+public interface CustionRepository {
+}

--- a/src/main/java/com/example/api/chat/repository/CustomChatRepository.java
+++ b/src/main/java/com/example/api/chat/repository/CustomChatRepository.java
@@ -1,4 +1,12 @@
 package com.example.api.chat.repository;
 
-public interface CustionRepository {
+import com.example.api.chat.domain.ChatSummary;
+import com.example.api.domain.Chat;
+
+import java.util.List;
+
+public interface CustomChatRepository {
+    void markChatsAsRead(Long chatRoomId, Long readBy);
+    List<Chat> findChats(Long chatRoomId, String lastChatId);
+    List<ChatSummary> aggregateChatSummaries(List<Long> chatRoomIds, Long memberId);
 }

--- a/src/main/java/com/example/api/chat/repository/CustomChatRepositoryImpl.java
+++ b/src/main/java/com/example/api/chat/repository/CustomChatRepositoryImpl.java
@@ -1,4 +1,78 @@
 package com.example.api.chat.repository;
 
-public class CustomChatReposityImpl {
+import com.example.api.chat.domain.ChatSummary;
+import com.example.api.domain.Chat;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomChatRepositoryImpl implements CustomChatRepository {
+    private final MongoTemplate mongoTemplate;
+    
+
+    @Override
+    public void markChatsAsRead(Long chatRoomId, Long readBy) {
+        Query query = new Query(Criteria.where("roomId").is(chatRoomId)
+                .and("receiverId").is(readBy)
+                .and("isRead").is(false));
+        Update update = new Update();
+        update.set("isRead", true);
+        mongoTemplate.updateMulti(query, update, Chat.class);
+    }
+
+    @Override
+    public List<Chat> findChats(Long chatRoomID, String lastChatId) {
+        Query query = new Query(
+                Criteria.where("roomId").is(chatRoomID)
+        ).with(Sort.by(Sort.Direction.DESC, "_id")).limit(100);
+
+        if (lastChatId != null) {
+            query.addCriteria(Criteria.where("_id").lt(new ObjectId(lastChatId)));
+        }
+
+        return mongoTemplate.find(query, Chat.class);
+    }
+
+  
+
+    @Override
+    public List<ChatSummary> aggregateChatSummaries(List<Long> roomIds, Long memberId) {
+        Criteria matchCriteria = Criteria.where("roomId").in(roomIds);
+        AggregationOperation match = Aggregation.match(matchCriteria);
+
+        AggregationOperation sort = Aggregation.sort(Sort.Direction.DESC, "sendTime");
+
+        AggregationOperation group = Aggregation.group("roomId")
+                .first("roomId").as("roomId")
+                .first("content").as("lastChatContent")
+                .first("sendTime").as("lastChatTime")
+                .sum(ConditionalOperators
+                        .when(new Criteria().andOperator(
+                                Criteria.where("receiverId").is(memberId),
+                                Criteria.where("isRead").is(false)
+                        ))
+                        .then(1)
+                        .otherwise(0))
+                .as("numberOfUnreadChats");
+
+        Aggregation aggregation = Aggregation.newAggregation(match, sort, group);
+
+        AggregationResults<ChatSummary> results = mongoTemplate.aggregate(
+                aggregation, "chat", ChatSummary.class);
+        return new ArrayList<>(results.getMappedResults());
+    }
 }

--- a/src/main/java/com/example/api/chat/repository/CustomChatRepositoryImpl.java
+++ b/src/main/java/com/example/api/chat/repository/CustomChatRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.api.chat.repository;
+
+public class CustomChatReposityImpl {
+}

--- a/src/main/java/com/example/api/chat/service/ChatService.java
+++ b/src/main/java/com/example/api/chat/service/ChatService.java
@@ -1,6 +1,6 @@
 package com.example.api.chat.service;
 
-import com.example.api.chat.controller.dto.RequestUserId;
+import com.example.api.chat.controller.dto.request.UserIdRequest;
 import com.example.api.chat.controller.dto.request.ChatSendRequest;
 import com.example.api.chat.controller.dto.request.ReadRequest;
 import com.example.api.chat.controller.dto.response.ChatSummaryResponse;
@@ -42,13 +42,15 @@ public class ChatService {
         return "메세지 읽기 성공~";
     }
 
-    public ChatSummaryResponse getChatSummaries(RequestUserId requestUserId) {
+    @Transactional(readOnly = true)
+    public ChatSummaryResponse getChatSummaries(UserIdRequest requestUserId) {
         List<ChatRoom> chatRooms = chatRoomRepository.findByUserId(requestUserId.userId());
         List<Long> chatRoomIds = chatRooms.stream().map(ChatRoom::getChatRoomId).toList();
         List<ChatSummary> chatSummaries = chatRepository.aggregateChatSummaries(chatRoomIds, requestUserId.userId());
         return new ChatSummaryResponse(chatRooms, chatSummaries);
     }
 
+    @Transactional(readOnly = true)
     public List<Chat> getChats(Long chatRoomId, String lastChatId) {
         return chatRepository.findChats(chatRoomId,lastChatId);
     }

--- a/src/main/java/com/example/api/chat/service/ChatService.java
+++ b/src/main/java/com/example/api/chat/service/ChatService.java
@@ -1,0 +1,52 @@
+package com.example.api.chat.service;
+
+import com.example.api.chat.controller.dto.request.ChatSendRequest;
+import com.example.api.chat.repository.ChatRepository;
+import com.example.api.chat.repository.ChatRoomRepository;
+import com.example.api.chat.service.model.ChatSender;
+import com.example.api.domain.Chat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatRepository chatRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatSender chatSender;
+
+    @Transactional
+    public String sendMessage(ChatSendRequest request) {
+        Chat chat = saveChat(request);
+        messageSender.send(savedMessage);
+        return "메세지 전송 성공~";
+    }
+
+    private Chat saveChat(ChatSendRequest request) {
+        Chat chat = Chat.from(request);
+        return messageRepository.save(message);
+    }
+
+    @Transactional
+    public String readMessages(ReadRequest request) {
+        messageRepository.markMessagesAsRead(request.roomId(), request.memberId());
+        messageSender.sendReadResponse(request);
+        return "메세지 읽기 성공~";
+    }
+
+    public ChatSummaryResponse getChatSummaries(Member loginMember) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findByMemberId(loginMember.getId());
+        List<Long> chatRoomIds = chatRooms.stream().map(ChatRoom::getChatRoomId).toList();
+        List<ChatMessageSummary> chatMessageSummaries = messageRepository.aggregateMessageSummaries(chatRoomIds, loginMember.getId());
+        return new ChatSummaryResponse(chatRooms, chatMessageSummaries);
+    }
+
+    public List<Message> getMessages(Long chatRoomId, String lastMessageId) {
+        return messageRepository.findMessages(chatRoomId,lastMessageId);
+    }
+
+    public List<ChatRoom> getChatRooms(Long memberId) {
+        return chatRoomRepository.findByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/example/api/chat/service/model/ChatSender.java
+++ b/src/main/java/com/example/api/chat/service/model/ChatSender.java
@@ -1,0 +1,23 @@
+package com.example.api.chat.service.model;
+
+import com.example.api.chat.controller.dto.request.ReadRequest;
+import com.example.api.chat.controller.dto.response.ReadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatSender {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void send(Message message) {
+        messagingTemplate.convertAndSend("/room/"+ message.getRoomId(), message);
+    }
+
+    public void sendReadResponse(ReadRequest request) {
+        ReadResponse readResponse = new ReadResponse(request.userId());
+        messagingTemplate.convertAndSend("/room/" + request.roomId(), readResponse);
+    }
+}

--- a/src/main/java/com/example/api/chat/service/model/ChatSender.java
+++ b/src/main/java/com/example/api/chat/service/model/ChatSender.java
@@ -2,8 +2,8 @@ package com.example.api.chat.service.model;
 
 import com.example.api.chat.controller.dto.request.ReadRequest;
 import com.example.api.chat.controller.dto.response.ReadResponse;
+import com.example.api.domain.Chat;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Component;
 public class ChatSender {
     private final SimpMessagingTemplate messagingTemplate;
 
-    public void send(Message message) {
-        messagingTemplate.convertAndSend("/room/"+ message.getRoomId(), message);
+    public void send(Chat chat) {
+        messagingTemplate.convertAndSend("/room/"+ chat.getRoomId(), chat);
     }
 
     public void sendReadResponse(ReadRequest request) {

--- a/src/main/java/com/example/api/domain/Chat.java
+++ b/src/main/java/com/example/api/domain/Chat.java
@@ -1,5 +1,6 @@
 package com.example.api.domain;
 
+import com.example.api.chat.controller.dto.request.ChatSendRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -21,7 +22,7 @@ public class Chat {
     protected Chat() {
     }
 
-    public static Chat from(chatSendRequest chatSendRequest){
+    public static Chat from(ChatSendRequest chatSendRequest){
         Chat chat = new Chat();
         chat.content = chatSendRequest.content();
         chat.roomId = chatSendRequest.roomId();

--- a/src/main/java/com/example/api/domain/Chat.java
+++ b/src/main/java/com/example/api/domain/Chat.java
@@ -11,7 +11,7 @@ import java.util.Date;
 @Document(collection = "chat")
 public class Chat {
     @Id
-    private Long id;
+    private String id;
     private String content;
     private Long roomId;
     private Long senderId;

--- a/src/main/java/com/example/api/domain/Chat.java
+++ b/src/main/java/com/example/api/domain/Chat.java
@@ -1,43 +1,47 @@
 package com.example.api.domain;
 
 import jakarta.persistence.*;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.util.Date;
 
-import static jakarta.persistence.FetchType.*;
-
-@Entity
 @Getter
-@Setter
-@EqualsAndHashCode
-@Table(name = "CHAT")
+@Document(collection = "chat")
 public class Chat {
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long chatId;
+    private Long id;
+    private String content;
+    private Long roomId;
+    private Long senderId;
+    private Long receiverId;
+    private Date sendTime;
+    private Boolean isRead;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "CHAT_ROOM_ID")
-    private ChatRoom chatRoom;
+    protected Chat() {
+    }
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "ACCOUNT_UNIQUE_ID")
-    private Account account;
+    public static Chat from(chatSendRequest chatSendRequest){
+        Chat chat = new Chat();
+        chat.content = chatSendRequest.content();
+        chat.roomId = chatSendRequest.roomId();
+        chat.senderId = chatSendRequest.senderId();
+        chat.receiverId = chatSendRequest.receiverId();
+        chat.sendTime = new Date();
+        chat.isRead = false;
+        return chat;
+    }
 
-    private String chatContent;
-
-    @Column(name = "CHAT_DELETED", columnDefinition = "BOOLEAN DEFAULT false")
-    private boolean deleted;
-
-    @Column(name = "CHAT_REGISTER_DATE")
-    private LocalDateTime chatRegisterDate;
-
-    @PrePersist
-    protected void onCreate() {
-        this.chatRegisterDate = LocalDateTime.now();
+    @Override
+    public String toString() {
+        return "Message{" +
+                "id=" + id +
+                ", content='" + content + '\'' +
+                ", roomId=" + roomId +
+                ", senderId=" + senderId +
+                ", receiverId=" + receiverId +
+                ", sendTime=" + sendTime +
+                ", isRead=" + isRead +
+                '}';
     }
 }

--- a/src/main/java/com/example/api/global/config/WebSocketConfig.java
+++ b/src/main/java/com/example/api/global/config/WebSocketConfig.java
@@ -1,0 +1,4 @@
+package com.example.api.global.config;
+
+public class WebSocketConfig {
+}

--- a/src/main/java/com/example/api/global/config/WebSocketConfig.java
+++ b/src/main/java/com/example/api/global/config/WebSocketConfig.java
@@ -1,4 +1,25 @@
 package com.example.api.global.config;
 
-public class WebSocketConfig {
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/room");
+        config.setApplicationDestinationPrefixes("/chat");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,9 @@ spring.h2.console.path=/h2-console
 # Logging (Optional)
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# Mongo Database Configuration
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=chatdb
+

--- a/src/test/java/com/example/api/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/example/api/chat/service/ChatServiceTest.java
@@ -1,0 +1,95 @@
+package com.example.api.chat.service;
+
+import com.example.api.chat.controller.dto.request.ReadRequest;
+import com.example.api.chat.repository.ChatRepository;
+import com.example.api.chat.repository.ChatRoomRepository;
+import com.example.api.domain.Account;
+import com.example.api.domain.Chat;
+import com.example.api.domain.ChatRoom;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import com.example.api.chat.controller.dto.request.ChatSendRequest;
+
+import java.util.List;
+
+
+@SpringBootTest()
+@Transactional
+@Rollback(false)
+class ChatServiceTest {
+    @Autowired ChatService chatService;
+    @Autowired ChatRoomRepository chatRoomRepository;
+    @Autowired ChatRepository chatRepository;
+
+    Account receiver;
+    Account sender;
+    ChatRoom givenChatRoom;
+    Chat givenChat;
+
+    @BeforeEach
+    void setUp() {
+        chatRoomRepository.deleteAll();
+        chatRepository.deleteAll();
+        setMembers(); // Members 설정 추가
+        setChatRoom();
+    }
+
+    private void setMembers() {
+        sender = new Account(); // 필요한 필드 설정
+        sender.setAccountId(1L); // ID 설정 (테스트용)
+
+        receiver = new Account(); // 필요한 필드 설정
+        receiver.setAccountId(2L); // ID 설정 (테스트용)
+    }
+    private void setChatRoom() {
+        ChatRoom chatRoom = new ChatRoom();
+        givenChatRoom = chatRoomRepository.save(chatRoom);
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("채팅 전송")
+    void sendChat() {
+        // Given
+        ChatSendRequest request = makeChatSendRequest();
+
+        // When
+        String result = chatService.sendChat(request);
+
+        // Then
+        List<Chat> chats = chatRepository.findAll();
+        Chat savedMessage = chats.get(chats.size()-1);
+        Assertions.assertFalse(savedMessage.getIsRead());
+        Assertions.assertEquals("메세지 전송 성공~", result);
+    }
+
+    private ChatSendRequest makeChatSendRequest() {
+        return new ChatSendRequest(
+                givenChatRoom.getChatRoomId(),
+                sender.getAccountId(),
+                receiver.getAccountId(),
+                "안녕 못한다."
+        );
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("채팅 읽기")
+    void readChat(){
+        // Given
+        ReadRequest request = new ReadRequest(1L, 2L);
+
+        // When
+        String result = chatService.readChats(request);
+
+        // Then
+        List<Chat> chats = chatRepository.findChats(1L, null);
+        for (Chat chat : chats) {
+            Assertions.assertTrue(chat.getIsRead());
+        }
+        Assertions.assertEquals("메세지 읽기 성공~", result);
+    }
+}


### PR DESCRIPTION
#기능
채팅 전송
채팅 읽기
채팅방 미리보기(최근 채팅 축약 정보)
채팅방 메세지 가져오기 

STOMP으로 구현
채팅은 MongoDB, 채팅방은 테스트는 H2, 배포는 MySQL 사용
채팅방 메세지는 기본적으로 마지막 채팅 기준 100개를 가져오고, 이전 채팅을 보고 싶으면 LastChatId를 기준으로 100개씩 가져와짐

#30 Mongo DB 사용에 따른  Chat 도메인 변경을 cherry-pick 하여 커밋을 가져왔기 때문에 30번은 따로 PR하지 않고, 27번 이슈가 통과되면 같이 close 하겠습니다.