### PR TITLE
Feat/#5 전화번호 인증 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-.env
+.envapplication.properties

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
 
     // env 파일 읽도록 도와주는 라이브러리
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
+    //회원가입 어노테이션 사용
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //비밀번호 암호화
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
 
     //비밀번호 암호화
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    //CoolSMS 전화번호 인증
+    implementation 'net.nurigo:sdk:4.2.7'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/api/auth/AuthRepository.java
+++ b/src/main/java/com/example/api/auth/AuthRepository.java
@@ -1,0 +1,11 @@
+package com.example.api.auth;
+
+import com.example.api.domain.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+public interface AuthRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+
+}
+

--- a/src/main/java/com/example/api/auth/register/Config/SecurityConfig.java
+++ b/src/main/java/com/example/api/auth/register/Config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.example.api.auth.register.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                .requestMatchers("/api/v1/auth/register").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .formLogin(form -> form.defaultSuccessUrl("/").permitAll());
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/api/auth/register/RegisterController.java
+++ b/src/main/java/com/example/api/auth/register/RegisterController.java
@@ -1,0 +1,23 @@
+package com.example.api.auth.register;
+
+import com.example.api.auth.register.dto.RegisterRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth/register")
+public class RegisterController {
+    private final RegisterService registerService;
+
+    public RegisterController(RegisterService registerService) {
+        this.registerService = registerService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public String register(@Valid @RequestBody RegisterRequest request) {
+        registerService.register(request);
+        return "Registration successful";
+    }
+}

--- a/src/main/java/com/example/api/auth/register/RegisterService.java
+++ b/src/main/java/com/example/api/auth/register/RegisterService.java
@@ -1,0 +1,50 @@
+package com.example.api.auth.register;
+
+import com.example.api.auth.AuthRepository;
+import com.example.api.auth.register.dto.RegisterRequest;
+import com.example.api.domain.Account;
+import com.example.api.exception.BusinessException;
+import com.example.api.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Service
+public class RegisterService {
+    private final AuthRepository authRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public void register(RegisterRequest request) {
+        // 중복 로그인 ID 확인
+        validateDuplicateLoginId(request.getLoginId());
+
+        // Account 엔티티 생성 (빌더 사용하지 않음)
+        Account account = new Account();
+        account.setLoginId(request.getLoginId());
+        account.setPassword(passwordEncoder.encode(request.getPassword())); // 비밀번호 암호화
+        account.setName(request.getName());
+        account.setEmail(request.getEmail());
+        account.setSex(request.getSex());
+        account.setAge(request.getAge());
+        account.setPhoneNumber(request.getPhoneNumber());
+        account.setNickname(request.getNickname());
+        account.setRegisteredDatetime(new Date()); // 현재 시간
+        account.setStarPoint(0.0f); // 초기값 설정
+        account.setWorkCount(0); // 초기값 설정
+        account.setDeleted(false); // 초기값 설정
+
+        // 엔티티 저장
+        authRepository.save(account);
+    }
+
+    // 중복 로그인 ID 검증
+    private void validateDuplicateLoginId(String loginId) {
+        if (authRepository.existsByLoginId(loginId)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_LOGIN_ID);
+        }
+    }
+}
+

--- a/src/main/java/com/example/api/auth/register/dto/RegisterRequest.java
+++ b/src/main/java/com/example/api/auth/register/dto/RegisterRequest.java
@@ -1,0 +1,33 @@
+package com.example.api.auth.register.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RegisterRequest {
+    @NotBlank
+    private String loginId;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String sex;
+
+    private int age;
+
+    private String phoneNumber;
+
+    private String nickname;
+
+}

--- a/src/main/java/com/example/api/auth/register/dto/RegisterResponse.java
+++ b/src/main/java/com/example/api/auth/register/dto/RegisterResponse.java
@@ -1,0 +1,11 @@
+package com.example.api.auth.register.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RegisterResponse {
+    private final String message;
+    private final String loginId;
+}

--- a/src/main/java/com/example/api/auth/verification/VerificationController.java
+++ b/src/main/java/com/example/api/auth/verification/VerificationController.java
@@ -1,0 +1,34 @@
+package com.example.api.auth.verification;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.example.api.auth.verification.dto.verifyRequest;
+import com.example.api.auth.verification.dto.sendRequest;
+
+@RestController
+@RequestMapping("/api/v1/verification")
+@RequiredArgsConstructor
+public class VerificationController {
+
+    private final VerificationService verificationService;
+
+
+    @PostMapping("/send")
+    public ResponseEntity<String> sendSms(@RequestBody @Valid sendRequest request) {
+        verificationService.sendVerificationCode(request.getPhoneNumber());
+        return ResponseEntity.ok("인증 코드가 발송되었습니다.");
+    }
+
+
+    @PostMapping("/verify")
+    public ResponseEntity<String> verifyCode(@RequestBody @Valid verifyRequest request) {
+        boolean isVerified = verificationService.verifyCode(request.getPhoneNumber(), request.getEnteredCode());
+        if (isVerified) {
+            return ResponseEntity.ok("인증 성공");
+        } else {
+            return ResponseEntity.badRequest().body("인증 실패");
+        }
+    }
+}

--- a/src/main/java/com/example/api/auth/verification/VerificationService.java
+++ b/src/main/java/com/example/api/auth/verification/VerificationService.java
@@ -1,0 +1,49 @@
+package com.example.api.auth.verification;
+
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+    private final DefaultMessageService messageService;
+
+    @Value("${coolsms.api.number}")
+    private String fromNumber;
+
+    private final Map<String, String> verificationCodes = new HashMap<>();
+
+    public void sendVerificationCode(String phoneNumber) {
+        String verificationCode = generateVerificationCode();
+
+        verificationCodes.put(phoneNumber, verificationCode);
+
+        Message message = new Message();
+        message.setFrom(fromNumber);
+        message.setTo(phoneNumber);
+        message.setText("인증번호는 " + verificationCode + "입니다.");
+
+        messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+
+
+    public boolean verifyCode(String phoneNumber, String enteredCode) {
+        String storedCode = verificationCodes.get(phoneNumber);
+        return enteredCode.equals(storedCode);
+    }
+
+
+    private String generateVerificationCode() {
+        Random random = new Random();
+        return String.valueOf(100000 + random.nextInt(900000));
+    }
+}

--- a/src/main/java/com/example/api/auth/verification/config/CoolSmsConfig.java
+++ b/src/main/java/com/example/api/auth/verification/config/CoolSmsConfig.java
@@ -1,0 +1,26 @@
+package com.example.api.auth.verification.config;
+
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CoolSmsConfig {
+
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+
+    @Value("${coolsms.api.secret}")
+    private String apiSecret;
+
+    @Bean
+    public DefaultMessageService defaultMessageService() {
+        return NurigoApp.INSTANCE.initialize(
+                apiKey,
+                apiSecret,
+                "https://api.coolsms.co.kr");
+    }
+}
+

--- a/src/main/java/com/example/api/auth/verification/dto/sendRequest.java
+++ b/src/main/java/com/example/api/auth/verification/dto/sendRequest.java
@@ -1,0 +1,10 @@
+package com.example.api.auth.verification.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class sendRequest {
+    private String phoneNumber;
+}

--- a/src/main/java/com/example/api/auth/verification/dto/verifyRequest.java
+++ b/src/main/java/com/example/api/auth/verification/dto/verifyRequest.java
@@ -1,0 +1,12 @@
+package com.example.api.auth.verification.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class verifyRequest {
+    private String phoneNumber;
+    private String enteredCode;
+}
+

--- a/src/main/java/com/example/api/exception/ErrorCode.java
+++ b/src/main/java/com/example/api/exception/ErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "-000", "서버 에러");
+    SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "-000", "서버 에러"),
+    DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST, "-001", "중복된 ID입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorCode;
@@ -17,3 +18,4 @@ public enum ErrorCode {
         this.errorDescription = errorDescription;
     }
 }
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,9 @@ spring.h2.console.path=/h2-console
 # Logging (Optional)
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# CoolSMS API Configuration
+coolsms.api.key=NCSPMBGXWN650DSN
+coolsms.api.secret=ETXDRJJNEO6YJZYXGZ8NT08OCEFKUCB8
+coolsms.api.number=01077583994
+


### PR DESCRIPTION
입력한 전화번호로 랜덤 인증번호 6자리를 생성해 CoolSMS API를 이용하여 해당 인증번호를 보낸 후 
사용자가 입력한 번호와 랜덤 인증번호가 동일한지 검증하는 흐름으로 동작합니다.

검증을 위해 랜덤 인증번호를 임시로 저장해야 했는데 데이터베이스 모델을 수정하기 어려워서 
임시 저장소로 Map을 사용하였습니다.

Postman으로 테스트를 진행했을 때 200 OK 상태코드는 반환되었으나 
설정한 메시지가 아닌 로그인 페이지 HTML 코드가 반환되었습니다. 
응답 처리에서 문제가 있는 것 같은데 해결하지 못했습니다. 도움 부탁드립니다.